### PR TITLE
Send whole message to LED service

### DIFF
--- a/server.py
+++ b/server.py
@@ -150,7 +150,7 @@ class Bluetooth():
         return (btn_a, btn_b)
 
     def putLed(self, name, msg):
-        self.led_iface[name].WriteValue([ord(msg[0])], ())
+        self.led_iface[name].WriteValue(map(ord, msg), ())
         print "Sent", msg
 
     def __del__(self):


### PR DESCRIPTION
In the current implementation only the first symbol of the message is sent to LED service. 
After this commit while message will be sent to the LED.